### PR TITLE
Add conda-forge instructions, use pytest for besselaesnew, and add test coverage

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,6 @@ install:
   - conda create -q --name python%PYTHON_VERSION% python=%PYTHON_VERSION%
   - activate python%PYTHON_VERSION%
   - conda install -q --name python%PYTHON_VERSION% setuptools numpy scipy matplotlib jupyter pytest libpython m2w64-toolchain
-  - python.exe setup.py build_ext --inplace --compiler=mingw32 --fcompiler=gfortran
   - python.exe setup.py install
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
   - conda update --quiet conda
   # Avoid noise from matplotlib
   - mkdir -p $HOME/.config/matplotlib
-  - conda install -q python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib jupyter pytest pytest-cov
+  - conda install -q python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib jupyter pytest pytest-cov coveralls
   - conda info -a
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,11 +59,14 @@ before_install:
   - conda update --quiet conda
   # Avoid noise from matplotlib
   - mkdir -p $HOME/.config/matplotlib
-  - conda install -q python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib jupyter pytest
+  - conda install -q python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib jupyter pytest pytest-cov
   - conda info -a
 
 install:
   - python setup.py install 
   
 script: 
-  - pytest
+  - pytest --cov=timml tests/
+
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![travis][travis-img]](https://travis-ci.org/mbakker7/timml)
-[![appveyor][appveyor-img]](https://ci.appveyor.com/project/mbakker7/timml/branch/master)  
+[![appveyor][appveyor-img]](https://ci.appveyor.com/project/mbakker7/timml/branch/master)
 [![coveralls][coveralls-img]](https://coveralls.io/github/jentjr/timml?branch=master)
 
 [travis-img]: https://img.shields.io/travis/mbakker7/timml/master.svg?label=Linux+/+macOS

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-[![Build Status](https://travis-ci.org/mbakker7/timml.svg?branch=master)](https://travis-ci.org/mbakker7/timml)
-[![Build status](https://ci.appveyor.com/api/projects/status/github/mbakker7/timml?branch=master&svg=true)](https://ci.appveyor.com/project/mbakker7/timml/branch/master)
+[![travis][travis-img]](https://travis-ci.org/mbakker7/timml)
+[![appveyor][appveyor-img]](https://ci.appveyor.com/project/mbakker7/timml/branch/master)  
+[![coveralls][coveralls-img]](https://coveralls.io/github/jentjr/timml?branch=master)
+
+[travis-img]: https://img.shields.io/travis/mbakker7/timml/master.svg?label=Linux+/+macOS
+[appveyor-img]: https://img.shields.io/appveyor/ci/mbakker7/timml/master.svg?label=Windows
+[coveralls-img]: https://img.shields.io/coveralls/github/jentjr/timml/master.svg?label=coveralls
+
 # TimML, A Multi-Layer, Analytic Element Model
 
 ## Introduction
@@ -16,14 +22,14 @@ TimML is coded in Python; use is made of FORTRAN extensions to improve performan
 
 **Python versions:**
 
-TimML requires **Python** > 3.5 and can be installed from PyPI.
+TimML requires **Python** >= 3.5 and can be installed from PyPI, or conda-forge.
 The PyPI installation includes compiled versions of the FORTRAN extension
 for both Windows and MacOS.
 
 
 **Dependencies:**
 
-TimML requires **NumPy** 1.12 (or higher) and **matplotlib** 2.0 (or higher). 
+TimML requires **NumPy** >=1.12, **Scipy** >=0.19 and **matplotlib** >=2.0. 
 
 **For base Python distributions:**
 
@@ -39,6 +45,20 @@ To uninstall TimML type:
 
     pip uninstall timml
     
+**For Anaconda Python distributions:**
+
+To install
+
+    conda install -c conda-forge timml
+    
+To update
+
+    conda update timml
+    
+To uninstall
+
+    conda uninstall timml
+
 ## Documentation
 
 * The manual is available from the docs directory or can be viewed [here](http://mbakker7.github.io/timml/docs/builddocs/html/index.html).

--- a/tests/test_besselaes.py
+++ b/tests/test_besselaes.py
@@ -1,0 +1,55 @@
+import numpy as np
+from numpy.testing import assert_allclose
+from timml.besselaesnew import besselaesnew
+
+besselaesnew.initialize()
+
+"""
+x=2.0
+y=1.0
+z1=-3.0 - 1.0j
+z2=2.0 + 2.0j
+lambda=[0.0, 2.0, 11.0]
+order = (0,1)
+ilap=1
+naq=3
+
+lambda is a keyword in Python, so use order of function arguments
+
+"""
+
+
+def potbesldho(x):
+    pot = besselaesnew.potbesldho(2.0, 1.0, np.complex(-3.0, -1.0), np.complex(2.0, 2.0), 
+            [0.0, 2.0, 11.0], x, 1, 3)
+    return pot
+
+def test_potbesldho():
+    assert_allclose(potbesldho(0), np.array([-0.31055947, -0.23498503, -0.30327438]))
+    assert_allclose(potbesldho(1), np.array([-0.17694283, -0.15257055, -0.17583515]))
+
+
+def test_potbesldv():
+    potv = besselaesnew.potbesldv(2.0, 1.0, np.complex(-3.0, -1.0), np.complex(2.0, 2.0),
+            [0.0, 2.0, 11.0], 1, 1, 3)
+    assert_allclose(potv[0], np.array([-0.31055947, -0.23498503, -0.30327438]))
+    assert_allclose(potv[1], np.array([-0.17694283, -0.15257055, -0.17583515]))
+
+def test_disbesldho():
+    qxqy_zero = besselaesnew.disbesldho(2.0, 1.0, np.complex(-3.0, -1.0), np.complex(2.0, 2.0),
+                  [0.0, 2.0, 11.0], 0, 1, 3)
+    assert_allclose(qxqy_zero[0], np.array([-0.170131146, -0.18423853, -0.173157849]))
+    assert_allclose(qxqy_zero[1], np.array([0.0274405074, 0.0888068675, 0.0342656083]))
+
+    qxqy_one = besselaesnew.disbesldho(2.0, 1.0, np.complex(-3.0, -1.0), np.complex(2.0, 2.0),
+                 [0.0, 2.0, 11.0], 1, 1, 3)
+    assert_allclose(qxqy_one[0], np.array([-0.10412493, -0.1084466406, -0.104477618]))
+    assert_allclose(qxqy_one[1], np.array([0.106176131, 0.1162738781, 0.1067421121]))
+
+def test_disbesldv():
+    qxqyv = besselaesnew.disbesldv(2.0, 1.0, np.complex(-3.0, -1.0), np.complex(2.0, 2.0),
+              [0.0, 2.0, 11.0], 1, 1, 3)
+    assert_allclose(qxqyv[0], np.array([-0.17013114606375021, -0.18423853257632447, -0.17315784943727297]))
+    assert_allclose(qxqyv[2], np.array([2.7440507429637e-002, 8.880686745447e-002, 3.426560831291e-002]))
+    assert_allclose(qxqyv[1], np.array([-0.10412493484448178, -0.10844664064434061, -0.10447761803194042]))
+    assert_allclose(qxqyv[3], np.array([0.10617613097471285, 0.11627387807684744, 0.10674211206906066]))


### PR DESCRIPTION
Mark,

This pull request adds the besseltest program in `besselaesnew.f95` for use with pytest, and adds test coverage using coverage.py. With coverage.py and pytest-cov installed, the tests can be run in the timml directory with `pytest --cov=timml tests/`. The tests are ran with Travis and the coverage results are reported with coveralls.io. I added the coverage badge to the README, and also update the installation instructions to include conda-forge.

Thanks,

Justin