### PR TITLE
circareasink: raise ValueError instead of bare raise

### DIFF
--- a/timml/circareasink.py
+++ b/timml/circareasink.py
@@ -114,7 +114,10 @@ class CircAreaSink(Element):
         else:
             r = np.sqrt((x - self.xc) ** 2 + (y - self.yc) ** 2)
             if r <= self.R:
-                raise 'CircAreaSink should add constant inside inhomogeneity'
+                raise ValueError(
+                    "CircAreaSink should be either fully inside or fully "
+                    "outside of an inhomogeneity"
+                )
         return rv
 
     def K1RI0r(self, rin):


### PR DESCRIPTION
The circular area sink doesn't raise a proper exception when not located well with regards to inhomogeneities.
The error message that was there was a little cryptic, I think this should be clearer to the user.

From searching for `raise`, I see that only Exceptions are raised for method inheritance, which are better handled by python abstract base classes (i.e. #35, although I guess most changes there are due to automatic formatting with black). I've chosen for 
a ValueError here, that seems most appropriate -- doing a bit more looking, it seems there are a number of print statement, where there should be probably also be ValueErrors (e.g. in initialize of StripAreaSink).

