### PR TITLE
Use JIT caching: suffer latency only once

### DIFF
--- a/timml/besselaesnumba/besselaesnumba.py
+++ b/timml/besselaesnumba/besselaesnumba.py
@@ -17,7 +17,7 @@ def initialize():
     pass
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def make_rbinom():
     rrange = np.arange(9.0)
     rbinom = np.zeros((9, 9))
@@ -80,7 +80,7 @@ AC1[8] = 0.573031034976631e-15
 BC1[8] = -0.340195779923156e-14
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def prepare_z(x, y, z1, z2):
     zin = np.complex(x, y)
     z1in = z1
@@ -97,7 +97,7 @@ def prepare_z(x, y, z1, z2):
     return zin, z1in, z2in, Lin, z, zplus1, zmin1
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def potbeslsho(x, y, z1, z2, labda, order, ilap, naq):
     """
     Parameters
@@ -158,7 +158,7 @@ def potbeslsho(x, y, z1, z2, labda, order, ilap, naq):
     return rv
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def potbeslsv(x, y, z1, z2, lab, order, ilap, naq):
     # Check if endpoints need to be adjusted using the largest labda (the first one)
     pot = np.zeros((order + 1, naq))
@@ -167,7 +167,7 @@ def potbeslsv(x, y, z1, z2, lab, order, ilap, naq):
     return pot
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def disbeslsho(x, y, z1, z2, labda, order, ilap, naq):
     # Input:
     #   x,y: Point where discharge is computed
@@ -238,7 +238,7 @@ def disbeslsho(x, y, z1, z2, labda, order, ilap, naq):
     return rv
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def disbeslsv(x, y, z1, z2, lab, order, ilap, naq):
     # locals
     qxqy = np.zeros((2 * (order + 1), naq))
@@ -250,7 +250,7 @@ def disbeslsv(x, y, z1, z2, lab, order, ilap, naq):
     return qxqy
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def potbesldho(x, y, z1, z2, labda, order, ilap, naq):
 
     # Input:
@@ -312,7 +312,7 @@ def potbesldho(x, y, z1, z2, labda, order, ilap, naq):
     return rv
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def potbesldv(x, y, z1, z2, lab, order, ilap, naq):
     pot = np.zeros((order + 1, naq))
     # Check if endpoints need to be adjusted using the largest labda (the first one)
@@ -321,7 +321,7 @@ def potbesldv(x, y, z1, z2, lab, order, ilap, naq):
     return pot
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def disbesldho(x, y, z1, z2, labda, order, ilap, naq):
     # Input:
     #   x,y: Point where discharge is computed
@@ -394,7 +394,7 @@ def disbesldho(x, y, z1, z2, labda, order, ilap, naq):
     return rv
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def disbesldv(x, y, z1, z2, lab, order, ilap, naq):
     qxqy = np.zeros((2 * (order + 1), naq))
     # Check if endpoints need to be adjusted using the largest labda (the first one)
@@ -405,7 +405,7 @@ def disbesldv(x, y, z1, z2, lab, order, ilap, naq):
     return qxqy
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def IntegralF(zin, z1in, z2in, Lin, labda, order, Rconv, lstype):
     czmzbarp = np.full(NTERMS + 1, np.complex(0.0, 0.0))
     cgamma = np.full((NTERMS + 1, NTERMS + 1), np.complex(0.0, 0.0))
@@ -484,7 +484,7 @@ def IntegralF(zin, z1in, z2in, Lin, labda, order, Rconv, lstype):
     return pot
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def IntegralG(zin, z1in, z2in, Lin, labda, order, Rconv, lstype):
     czmzbarp = np.full(NTERMS + 1, np.complex(0.0, 0.0))
     cgamma = np.full((NTERMS + 1, NTERMS + 1), np.complex(0.0, 0.0))
@@ -629,7 +629,7 @@ def IntegralG(zin, z1in, z2in, Lin, labda, order, Rconv, lstype):
     return wdis
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def IntegralLapLineDipole(zin, z1, z2, del0, ra, order):
     cg = np.full(order + 2, np.complex(0.0, 0.0))
     z = (2.0 * zin - (z1 + z2)) / (z2 - z1)
@@ -656,7 +656,7 @@ def IntegralLapLineDipole(zin, z1, z2, del0, ra, order):
     return comega
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def IntegralLapLineDipoleDis(zin, z1, z2, del0, ra, order):
     cg = np.full(order + 2, np.complex(0.0, 0.0))
 
@@ -688,7 +688,7 @@ def IntegralLapLineDipoleDis(zin, z1, z2, del0, ra, order):
     return wdis
 
 
-@numba.njit(nogil=True)
+@numba.njit(nogil=True, cache=True)
 def findm1m2(zin, z1in, z2in, Lin, labda, Rconv):
     # Break integral up in sections of max one labda
     # and find first (m1) and last (m2) section within radius of convergence


### PR DESCRIPTION
numba njit has a caching argument, which helpfully stores the compiled code. This massively reduces start-up time after first use (e.g. 14 seconds for a LeakyLineDoublet on my machine).