### PR TITLE
Convergence large radius

### DIFF
--- a/timml/besselaesnumba/besselaesnumba.py
+++ b/timml/besselaesnumba/besselaesnumba.py
@@ -121,7 +121,7 @@ def potbeslsho(x, y, z1, z2, labda, order, ilap, naq):
     lstype = 1
 
     # Radius of convergence
-    Rconv = 7.0
+    Rconv = 5.0
 
     # if (ilap==1) :
     #    istart = 1
@@ -183,7 +183,7 @@ def disbeslsho(x, y, z1, z2, labda, order, ilap, naq):
 
     rv = np.zeros((2, naq))
     # Radius of convergence
-    Rconv = 7.0
+    Rconv = 5.0
 
     # lstype = 1 means line-sink
     lstype = 1
@@ -267,7 +267,7 @@ def potbesldho(x, y, z1, z2, labda, order, ilap, naq):
     rv = np.zeros(naq)
 
     # Radius of convergence
-    Rconv = 7.0
+    Rconv = 5.0
 
     # lstype=2 means line-doublet
     lstype = 2
@@ -334,7 +334,7 @@ def disbesldho(x, y, z1, z2, labda, order, ilap, naq):
     #                   and mod.Helmholtz potentials in remaining spots
     rv = np.zeros((2, naq))
     # Radius of convergence
-    Rconv = 7.0
+    Rconv = 5.0
 
     # lstype=2 means line-doublet
     lstype = 2

--- a/timml/besselaesnumba/besselaesnumba.py
+++ b/timml/besselaesnumba/besselaesnumba.py
@@ -121,7 +121,10 @@ def potbeslsho(x, y, z1, z2, labda, order, ilap, naq):
     lstype = 1
 
     # Radius of convergence
-    Rconv = 5.0
+    if order > 5:
+        Rconv = 5.0
+    else:
+        Rconv = 7.0
 
     # if (ilap==1) :
     #    istart = 1
@@ -183,7 +186,10 @@ def disbeslsho(x, y, z1, z2, labda, order, ilap, naq):
 
     rv = np.zeros((2, naq))
     # Radius of convergence
-    Rconv = 5.0
+    if order > 5:
+        Rconv = 5.0
+    else:
+        Rconv = 7.0
 
     # lstype = 1 means line-sink
     lstype = 1
@@ -267,7 +273,10 @@ def potbesldho(x, y, z1, z2, labda, order, ilap, naq):
     rv = np.zeros(naq)
 
     # Radius of convergence
-    Rconv = 5.0
+    if order > 5:
+        Rconv = 5.0
+    else:
+        Rconv = 7.0
 
     # lstype=2 means line-doublet
     lstype = 2
@@ -334,7 +343,10 @@ def disbesldho(x, y, z1, z2, labda, order, ilap, naq):
     #                   and mod.Helmholtz potentials in remaining spots
     rv = np.zeros((2, naq))
     # Radius of convergence
-    Rconv = 5.0
+    if order > 5:
+        Rconv = 5.0
+    else:
+        Rconv = 7.0
 
     # lstype=2 means line-doublet
     lstype = 2

--- a/timml/constant.py
+++ b/timml/constant.py
@@ -153,7 +153,7 @@ class ConstantInside(Element):
                         mat[0:, ieq : ieq + e.nunknowns] += e.potinflayers(
                             self.xc[icp], self.yc[icp], self.layers
                         ).sum(0)
-                        ieq += e.nunknowns
+                    ieq += e.nunknowns # I decreased the tab here
                         # else:
                         #    mat[0, ieq:ieq+e. nunknowns] += -1
                 else:


### PR DESCRIPTION
Rconv = 5 when order > 5
Rconv = 7 when order <= 5
Didn't need to do this in the past. 
Did any round-off change in numba?
Better to approximate line-element with Taylor series (as in TTim) than the approximate polynomial we use now. 